### PR TITLE
Add pip requirements.txt file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+Flask
+requests
+requests-oauthlib


### PR DESCRIPTION
This makes it easier to install dependencies (i.e. using `pip install -r requirements.txt`).
