### PR TITLE
Fix Search Input Styles on Safari

### DIFF
--- a/static/stylesheet.css
+++ b/static/stylesheet.css
@@ -44,6 +44,7 @@ header {
 
 .search-form input {
     appearance: none;
+    -webkit-appearance: none;
     background: #333;
     border: 0;
     border-bottom: solid 3px transparent;


### PR DESCRIPTION
Safari is using default system styles for the search input and not applying the custom styles – it needs this `-webkit-appearance` property set to enable the custom styling.